### PR TITLE
Parsing additions

### DIFF
--- a/schemas-analyze/src/test/groovy/org/cedar/schemas/analyze/AnalyzersSpec.groovy
+++ b/schemas-analyze/src/test/groovy/org/cedar/schemas/analyze/AnalyzersSpec.groovy
@@ -79,7 +79,7 @@ class AnalyzersSpec extends Specification {
             endPrecision            : ChronoUnit.DAYS.toString(),
             endIndexable            : true,
             endZoneSpecified        : null,
-            endUtcDateTimeString    : '2010-10-01T23:59:59Z',
+            endUtcDateTimeString    : '2010-10-01T23:59:59.999Z',
             instantDescriptor       : ValidDescriptor.UNDEFINED,
             instantPrecision        : null,
             instantIndexable        : true,
@@ -132,6 +132,7 @@ class AnalyzersSpec extends Specification {
   def 'extracts date info from date strings'() {
     when:
     def result = new Analyzers.DateInfo(input, start)
+    println(result.utcDateTimeString)
 
     then:
     result.descriptor == descriptor
@@ -144,11 +145,16 @@ class AnalyzersSpec extends Specification {
     input                  | start || descriptor                | precision | indexable | zone | string
     '2042-04-02T00:42:42Z' | false || ValidDescriptor.VALID     | 'Nanos'   | true      | 'Z'  | '2042-04-02T00:42:42Z'
     '2042-04-02T00:42:42'  | false || ValidDescriptor.VALID     | 'Nanos'   | true      | null | '2042-04-02T00:42:42Z'
-    '2042-04-02'           | false || ValidDescriptor.VALID     | 'Days'    | true      | null | '2042-04-02T23:59:59Z'
+    '2042-04-02'           | false || ValidDescriptor.VALID     | 'Days'    | true      | null | '2042-04-02T23:59:59.999Z'
     '2042-04-02'           | true  || ValidDescriptor.VALID     | 'Days'    | true      | null | '2042-04-02T00:00:00Z'
+    '2042-05'              | true  || ValidDescriptor.VALID     | 'Months'  | true      | null | '2042-05-01T00:00:00Z'
+    '-2042-05'             | false || ValidDescriptor.VALID     | 'Months'  | true      | null | '-2042-05-31T23:59:59.999Z'
     '2042'                 | true  || ValidDescriptor.VALID     | 'Years'   | true      | null | '2042-01-01T00:00:00Z'
+    '1965'                 | false || ValidDescriptor.VALID     | 'Years'   | true      | null | '1965-12-31T23:59:59.999Z'
     '-5000'                | true  || ValidDescriptor.VALID     | 'Years'   | true      | null | '-5000-01-01T00:00:00Z'
+    '-3000'                | false || ValidDescriptor.VALID     | 'Years'   | true      | null | '-3000-12-31T23:59:59.999Z'
     '-100000001'           | true  || ValidDescriptor.VALID     | 'Years'   | false     | null | '-100000001-01-01T00:00:00Z'
+    '-100000002'           | false || ValidDescriptor.VALID     | 'Years'   | false     | null | '-100000002-12-31T23:59:59.999Z'
     'ABC'                  | true  || ValidDescriptor.INVALID   | null      | false     | null | null
     ''                     | true  || ValidDescriptor.UNDEFINED | null      | true      | null | null
     null                   | true  || ValidDescriptor.UNDEFINED | null      | true      | null | null

--- a/schemas-parse/src/main/groovy/org/cedar/schemas/parse/ISOParser.groovy
+++ b/schemas-parse/src/main/groovy/org/cedar/schemas/parse/ISOParser.groovy
@@ -425,11 +425,19 @@ class ISOParser {
   }
 
   static List<Link> parseLinks(GPathResult metadata) {
-    def linkNodes = metadata.distributionInfo.MD_Distribution.'**'.findAll {
+    def allLinkNodes = metadata.distributionInfo.MD_Distribution.'**'.findAll {
       it.name() == 'CI_OnlineResource'
     }
-    def uniqueLinks = linkNodes.collect(ISOParser.&parseLink).findAll() as Set
-    return uniqueLinks.toList()
+    def allUniqueLinks = allLinkNodes.collect(ISOParser.&parseLink).findAll() as Set
+
+    // Find all contact links and remove them
+    def allContactLinkNodes = metadata.distributionInfo.MD_Distribution.distributor.MD_Distributor.distributorContact.'**'.findAll {
+      it.name() == 'CI_OnlineResource'
+    }
+    def allUniqueContactLinks = allContactLinkNodes.collect(ISOParser.&parseLink).findAll() as Set
+
+    allUniqueLinks.removeAll(allUniqueContactLinks)
+    return allUniqueLinks.toList()
   }
 
   static Link parseLink(GPathResult node) {

--- a/schemas-parse/src/main/groovy/org/cedar/schemas/parse/ISOParser.groovy
+++ b/schemas-parse/src/main/groovy/org/cedar/schemas/parse/ISOParser.groovy
@@ -445,7 +445,7 @@ class ISOParser {
     def builder = Link.newBuilder()
     builder.linkName        = node.name?.CharacterString?.text()?.trim() ?: null
     builder.linkProtocol    = node.protocol?.CharacterString?.text()?.trim() ?: null
-    builder.linkUrl         = node.linkage?.URL?.text() ? StringEscapeUtils.unescapeXml(node.linkage.URL.text()) : null
+    builder.linkUrl         = StringEscapeUtils.unescapeXml(node.linkage?.URL?.text()?.trim()) ?: null
     builder.linkDescription = node.description?.CharacterString?.text()?.trim() ?: null
     builder.linkFunction    = node.function?.CI_OnLineFunctionCode?.@codeListValue?.text()?.trim() ?: null
     return builder.build()

--- a/schemas-parse/src/test/groovy/org/cedar/schemas/parse/ISOParserSpec.groovy
+++ b/schemas-parse/src/test/groovy/org/cedar/schemas/parse/ISOParserSpec.groovy
@@ -1,6 +1,5 @@
 package org.cedar.schemas.parse
 
-import org.cedar.schemas.avro.psi.Discovery
 import org.cedar.schemas.avro.geojson.LineStringType
 import org.cedar.schemas.avro.geojson.PointType
 import org.cedar.schemas.avro.geojson.PolygonType
@@ -370,10 +369,10 @@ class ISOParserSpec extends Specification {
     then:
     links instanceof List
     links.every { it instanceof Link }
-    links.size() == 1
+    links.size() == 1                                     // Distributor Contact link should not appear
     links[0].linkName == 'Super Important Access Link'
     links[0].linkProtocol == 'HTTP'
-    links[0].linkUrl == 'http://www.example.com'
+    links[0].linkUrl == 'http://www.example.com'          // Whitespace needs to be cleaned up
     links[0].linkDescription == 'Everything Important, All In One Place'
     links[0].linkFunction == 'search'
   }

--- a/schemas-parse/src/test/resources/test-iso-metadata.xml
+++ b/schemas-parse/src/test/resources/test-iso-metadata.xml
@@ -1359,7 +1359,7 @@
               <gmd:onLine>
                 <gmd:CI_OnlineResource>
                   <gmd:linkage>
-                    <gmd:URL>http://www.example.com</gmd:URL>
+                    <gmd:URL>         http://www.example.com        </gmd:URL>
                   </gmd:linkage>
                   <gmd:protocol>
                     <gco:CharacterString>HTTP</gco:CharacterString>
@@ -1380,6 +1380,24 @@
               </gmd:onLine>
             </gmd:MD_DigitalTransferOptions>
           </gmd:distributorTransferOptions>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:onlineResource>
+                    <gmd:CI_OnlineResource>
+                      <gmd:linkage>
+                        <gmd:URL>http://www.contact-example.com</gmd:URL>
+                      </gmd:linkage>
+                      <gmd:name>
+                        <gco:CharacterString>Contact Link That Shouldn't Appear</gco:CharacterString>
+                      </gmd:name>
+                    </gmd:CI_OnlineResource>
+                  </gmd:onlineResource>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
         </gmd:MD_Distributor>
       </gmd:distributor>
       <gmd:distributionFormat>


### PR DESCRIPTION
This PR adds more flexibility to the Schemas Analyzer to handle Year-Month dates; updates the accuracy of end-of-day timestamps to ms precision (ES indexing these as 23:59:59**.999** now instead of  23:59:59**.000**); and removes distributor contact links from the parsed links list.

Resolves #29, resolves #25, resolves cedardevs/feedback#10